### PR TITLE
修复iOS端 menu页：picker indicator 样式无法正常显示；words页：衍生词column-gap无法正常显示

### DIFF
--- a/miniprogram/pages/menu/menu.wxss
+++ b/miniprogram/pages/menu/menu.wxss
@@ -27,8 +27,8 @@ picker-view-column {
   height: 96rpx;
   border-top: 1px solid transparent;
   border-bottom: 1px solid transparent;
-  border-image: linear-gradient(to right,#FBFBFB,#FFAC30,#FBFBFB) 1 1;
-  border-image: linear-gradient(to right,#FBFBFB,#969656,#FBFBFB) 1 1;
+  /* border-image: linear-gradient(to right,#FBFBFB,#FFAC30,#FBFBFB) 1 1;
+  border-image: linear-gradient(to right,#FBFBFB,#969656,#FBFBFB) 1 1; */
   margin-left:25%;
 }
 /* 来自https://blog.csdn.net/Hero_rong/article/details/96971853的样式结束 */

--- a/miniprogram/pages/words/words.wxss
+++ b/miniprogram/pages/words/words.wxss
@@ -32,7 +32,7 @@ page {
   flex-shrink: 1;
   vertical-align: super;
   font-style: italic;
-  /* margin-bottom: 30rpx; */
+  padding-right: 3%;
 }
 
 .wordDeriRight {
@@ -40,6 +40,7 @@ page {
   width: 45%;
   flex-grow: 0;
   font-style:oblique;
+  padding-left: 3%;
 }
 
 .subcontainer_deri {
@@ -57,7 +58,7 @@ page {
   align-items: center;
   justify-content: center;
   width: 100%;
-  gap: 10%;
+  /* column-gap: 10%; */
   line-height: 27rpx;
   margin-top: 20rpx;
   margin-bottom: 20rpx;


### PR DESCRIPTION
fix: #12 

修复iOS端
menu页：picker indicator 样式无法正常显示
words页：衍生词column-gap无法正常显示