### PR TITLE
解决安卓已下载词典情况下无法离线使用问题

### DIFF
--- a/miniprogram/app.js
+++ b/miniprogram/app.js
@@ -1,6 +1,11 @@
 App({
   async onLaunch() {
-    this.initcloud()
+    try {
+      this.initcloud()
+    } catch {
+      console.log("Cloud can't be init")
+    }
+    
     this.globalData = {
     }
     console.log("onLaunch end")

--- a/miniprogram/pages/menu/menu.js
+++ b/miniprogram/pages/menu/menu.js
@@ -23,9 +23,14 @@ Page({
     if (actualLoad) {
       // onShow 中调用进行页面重载时 actualLoad 为 false, 此时不需要再次访问云端数据库
       console.log("actualLoad")
-      const db = wx.cloud.database()
-      const dictInfoRes = await db.collection('dictInfo').doc('content').get()
-      var dataTemp = dictInfoRes.data
+      try {
+        const db = wx.cloud.database()
+        const dictInfoRes = await db.collection('dictInfo').doc('content').get()
+        var dataTemp = dictInfoRes.data
+      } catch {
+        console.log('Offline')
+        app.globalData.offline = true
+      }
     }
 
     console.log('dataTemp: ', dataTemp)
@@ -34,7 +39,7 @@ Page({
     if (typeof(app.globalData.dictInfo) == "string") { // 此时即为没有 app.globalData.dictInfo
       app.globalData.dictInfo = new Object()
     }
-    if (actualLoad && (!app.globalData.dictInfo.marker || app.globalData.dictInfo.marker!=dataTemp.marker)) {
+    if (actualLoad && dataTemp && (!app.globalData.dictInfo.marker || app.globalData.dictInfo.marker!=dataTemp.marker)) {
       // console.log('app.globalData.dictInfo.marker: ', app.globalData.dictInfo.marker)
       // console.log('dataTemp.marker: ', dataTemp.marker)
 

--- a/miniprogram/pages/words/words.js
+++ b/miniprogram/pages/words/words.js
@@ -1,5 +1,4 @@
 const app = getApp()
-console.log('app: ', app)
 
 Page({
  
@@ -13,7 +12,8 @@ Page({
     showPlay: true,
     showMoreDeri: false,
     useMode: app.globalData.dictInfo.useMode,
-    showChinese: false
+    showChinese: false,
+    noAudio: false
   },
 
   mCount: function (word) {
@@ -164,11 +164,23 @@ Page({
     wx.hideLoading()
 
     // 预备“朗读”功能
-    this.InnerAudioContext = wx.createInnerAudioContext()
-    this.InnerAudioContext.src = 'https://dict.youdao.com/dictvoice?audio=' + dictionary[index]._id
-    this.InnerAudioContext.onEnded(() => {
-      app.globalData.timeout = setTimeout(this.onPlay, 1000)
-    })
+    try {
+      this.InnerAudioContext = wx.createInnerAudioContext()
+      this.InnerAudioContext.src = 'https://dict.youdao.com/dictvoice?audio=' + dictionary[index]._id
+      this.InnerAudioContext.onEnded(() => {
+        app.globalData.timeout = setTimeout(this.onPlay, 1000)
+      })
+    } catch(e) {
+      console.log(175, e)
+      this.setData({
+        noAudio: true
+      })
+    }
+    if (app.globalData.offline) {
+      this.setData({
+        noAudio: true
+      })
+    }
   },
 
   onShowChinese: function () {

--- a/miniprogram/pages/words/words.wxml
+++ b/miniprogram/pages/words/words.wxml
@@ -5,7 +5,7 @@
     <view class="container_grow1">
       <text class="main_word" wx:if='{{dictionary[index].len<13}}'>{{dictionary[index]._id}}</text>
       <text class="main_word_smaller" style="font-size: {{1000/dictionary[index].len}}rpx;" wx:else>{{dictionary[index]._id}}</text>
-      <view class="read_button_container" style="height: 100rpx; width: 50%; padding: 0;" bindtap="{{showPlay ? 'onPlay' : 'onPause'}}">
+      <view class="read_button_container" wx:if="{{!noAudio}}" style="height: 100rpx; width: 50%; padding: 0;" bindtap="{{showPlay ? 'onPlay' : 'onPause'}}">
         <text class="read_button" wx:if='{{showPlay}}'>朗读</text>
         <text class="read_button" wx:else>暂停</text>
       </view>


### PR DESCRIPTION
开发工具和安卓端亦可离线运转，iOS 端尚不行

已通过测试&审核，上线为0.3.5版
![image](https://user-images.githubusercontent.com/22675861/195818137-29cf87e1-8ca4-45c3-b913-877a6be3c152.png)
