### PR TITLE
体验版本 0.4.3 增加和调整按钮

### DIFF
--- a/miniprogram/app.wxss
+++ b/miniprogram/app.wxss
@@ -1,13 +1,13 @@
 /* 引入 weui 组件
 @import './miniprogram_npm/weui-miniprogram/weui-wxss/dist/style/weui.wxss'; */
-
+/* 
 page {
   --footer-height: 10vh;
   --button-size: 16vw;
   --button-color: #353535;
   --button-icon-size: 6vw;
-}
-
+} 
+*/
 text {
   color: #343a40;
 }
@@ -17,14 +17,43 @@ text {
   flex-direction: column;
   align-items: center;
   justify-content: space-around;
-  height: 95vh;
-  width: 98%;
+  height: 100vh;
+  width: 100vw;
+}
+
+.main_button_container {
+  height: 33vh;
+  align-self: flex-end;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  /* flex-grow: 0; */
+  flex: 0 0 auto;
+  /* justify-content: space-between; */
+  width: 100%;
+}
+
+.primary_button {
+  /* width: 61.8vw; */
+  border-radius: 0;
+  font-size: 36rpx;
+  font-weight: 500;
+  align-self: flex-start;
+  margin-top: 6vh;
+}
+
+.following_button {
+  border-radius: 0;
+  font-size: 36rpx;
+  font-weight: 500;
+  align-self: flex-start;
+  margin-top: 36rpx;
 }
 
 .btn1{
-  width: 61.8vw;
+  /* width: 61.8vw; */
   border-radius: 0;
-  font-size: 35rpx;
+  font-size: 36rpx;
   font-weight: 500;
 }
 

--- a/miniprogram/pages/menu/menu.wxml
+++ b/miniprogram/pages/menu/menu.wxml
@@ -1,7 +1,7 @@
 <!--pages/menu/menu.wxml--> 
 
 
-<view class="page_container" style="width: 100%;">
+<view class="page_container">
   <view class="title_container" style="height: 365rpx;"><text class="title">请选择您要使用的词库和模式</text></view>
   
   <picker-view 
@@ -22,7 +22,8 @@
     </picker-view-column>
   </picker-view>
 
-  <view class="page_container" style="height: 33%;">
-    <button type="primary" size='default' class='btn1' catchtap="onConfirm" style="width: 61.8vw; margin-bottom: 50rpx;" wx:if="{{showBtn}}">确定</button>
+  <view class="main_button_container">
+    <button type="primary" class='primary_button' catchtap="onConfirm" style="width: 61.8vw" wx:if="{{showBtn}}">就是这样</button>
+    <button type="default" class='following_button' catchtap="onConfirm" style="width: 61.8vw;" wx:if="{{showBtn}}">随便看看</button>
   </view>
 </view>

--- a/miniprogram/pages/menu/menu.wxss
+++ b/miniprogram/pages/menu/menu.wxss
@@ -25,10 +25,11 @@ picker-view {
   background-color: #FFF;
   text-align: center;
   box-sizing: border-box;
-  width: 95%;
+  width: 93vw;
   height: 50%;
   /* border-radius: 30rpx; */
   box-shadow: 0px 7px 6px -9px black;
+  margin-bottom: 12rpx;
 }
 
 picker-view-column {

--- a/miniprogram/pages/words/words.js
+++ b/miniprogram/pages/words/words.js
@@ -14,7 +14,8 @@ Page({
     useMode: app.globalData.dictInfo.useMode,
     showChinese: false,
     noAudio: false,
-    with3s: true
+    with3s: true,
+    showSetting: false
   },
 
   display_length_count: function (word) {
@@ -159,7 +160,8 @@ Page({
     this.setData({
       dictionary: dictionary,
       index: index,
-      fontRes: await this.calFontSize(dictionary[index].deris)
+      fontRes: await this.calFontSize(dictionary[index].deris),
+      showSetting: app.globalData.dictInfo.hasOwnProperty('no_high_school')
     })
 
     var _this = this
@@ -193,9 +195,10 @@ Page({
   },
 
   configFilter: function (filtername, filtering) {
+    let filtering_temp = app.globalData.dictInfo[filtername]
     app.globalData.dictInfo[filtername] = filtering
     wx.setStorageSync('dictInfo', app.globalData.dictInfo)
-    if (filtering) {
+    if (filtering != filtering_temp) {
       this.onLoad()
     }
   },
@@ -203,7 +206,7 @@ Page({
     let _this = this
     wx.showModal({
       title: '彻底屏蔽高中单词？',
-      content: '部分高中课纲单词在论文中有一些特定用法/释义，您可以选择是否保留它们',
+      content: '部分高中课纲单词在论文中有一些特定用法/释义，您可以选择是否保留它们\r\n您也可以随时通过“调整设置”修改此设定',
       confirmText: "屏蔽",
       cancelText: "保留",
       success (res) {
@@ -214,6 +217,10 @@ Page({
         }
       }
     })
+  },
+
+  onConfig: function () {
+    this.mayIFiltering('no_high_school')
   },
 
   onDone: function () {

--- a/miniprogram/pages/words/words.js
+++ b/miniprogram/pages/words/words.js
@@ -17,16 +17,6 @@ Page({
     with3s: true
   },
 
-  mCount: function (word) {
-    // 计算单词中"m"的个数，用于字号修正
-    try {
-      var lenRes = word.match(/m/g).length
-    } catch {
-      return 0
-    }
-    return lenRes
-  },
-
   display_length_count: function (word) {
     // 计算单词显示长度，单位：a 显示时占用 1 长度（过程中 a 等记为 14 长度，故最后除以14）
     var res = 0
@@ -212,8 +202,10 @@ Page({
   mayIFiltering: function (filtername) {
     let _this = this
     wx.showModal({
-      title: '简单词汇太多？',
-      content: '在构建词库的过程中，由于一些原因，部分存在高中课纲词汇的词汇组被保留了下来，是否将它们彻底屏蔽？',
+      title: '彻底屏蔽高中单词？',
+      content: '部分高中课纲单词在论文中有一些特定用法/释义，您可以选择是否保留它们',
+      confirmText: "屏蔽",
+      cancelText: "保留",
       success (res) {
         if (res.confirm) {
           _this.configFilter(filtername, true)

--- a/miniprogram/pages/words/words.wxml
+++ b/miniprogram/pages/words/words.wxml
@@ -44,12 +44,13 @@
       <text class="explain_zhcn" wx:else="index==0" style="font-style: oblique; color: rgba(0, 0, 0, 0.3);">点击查看释义（核对答案~）</text>
     </view>
 
-    <view class="container_grow1" style="height: 300rpx; align-self: flex-end; flex-grow: 0;">
-      <button type="primary" size='default' class='btn1' bindtap="onDone" style="width: 61.8vw;">我记住了</button>
-      <button type="default" size='default' class='btn1' bindtap="onNext" style="margin-bottom: 60rpx; width: 61.8vw;">还要努力</button>
-    </view>
-
   </view>
+
+  <view class="main_button_container" style="height: 33vh; align-self: flex-end; flex-grow: 0;" wx:if="{{!showMoreDeri}}">
+      <button type="primary" class='primary_button' bindtap="onDone" style="width: 61.8vw;">我记住了</button>
+      <button type="default" class='following_button' bindtap="onNext" style="width: 61.8vw;">还要努力</button>
+      <button type="default" class='following_button' bindtap="onConfig" style="width: 61.8vw;" wx:if="{{showSetting}}">调整设置</button>
+    </view>
 
   <view class="table_more_deri" wx:if="{{showMoreDeri}}">
     <view class="tr bg-w">
@@ -74,7 +75,7 @@
   </view>
 
   <button type="primary" class='btn1 bottom_back_from_more_deri' catchtap="onMoreDeri" style="width: 61.8vw;" wx:if="{{showMoreDeri}}">返回</button>
-  <!-- <view class="botton-right-float">
+  <!-- <view class="button-right-float">
     <picker mode="multiSelector" bindchange="bindMultiPickerChange" bindcolumnchange="bindMultiPickerColumnChange" value="{{multiIndex}}" range="{{multiArray}}">
       <text>选择词典</text>
       <text>/模式</text>

--- a/miniprogram/pages/words/words.wxss
+++ b/miniprogram/pages/words/words.wxss
@@ -11,19 +11,19 @@ page {
   flex-direction: column;
   align-items: center;
   justify-content: space-between;
-  height: 85%;
-  width: 80%;
+  height: 61vh;
+  width: 93vw;
   border: 1px solid #ddd;
   background-size: cover;
 	background-clip: content-box;
-  background-color: rgba(255, 250, 205, 0.1);
+  /* background-color: rgba(255, 250, 205, 0.1); */
   background-color: rgba(232, 232, 216, 0.1);
   box-sizing: border-box;
   position: relative;
-  margin: 8px;
-  margin-top: 5rpx;
-  margin-left: 35rpx;
-  margin: 5rpx 16rpx 0 35rpx;
+  /* margin: 8px; */
+  margin-top: 5vh;
+  /* margin-left: 12rpx; */
+  /* margin: 5vh 16rpx 0 35rpx; */
 }
 
 .total_count_text {
@@ -65,7 +65,7 @@ page {
 }
 
 .read_button {
-  font-size: 35rpx;
+  font-size: 36rpx;
   text-align: center;
   background-color: #07c160;
   color: #fff;
@@ -138,8 +138,8 @@ page {
   position: absolute;
   border: 50px solid transparent;
   border-top: 50px solid #fefefe;
-  top: -60px;
-  left: -65px;
+  top: -63px;
+  left: -60px;
   box-shadow: 0px -7px 6px -9px black;
   transform: rotate(135deg);
 }
@@ -149,8 +149,8 @@ page {
   position: absolute;
   border: 50px solid transparent;
   border-bottom: 50px solid #fefefe;
-  bottom: -60px;
-  right: -65px;
+  bottom: -63px;
+  right: -60px;
   box-shadow: 0px 7px 6px -9px black;
   transform: rotate(135deg);
 }
@@ -159,7 +159,7 @@ page {
   border: 0px solid darkgray;
   width: 100%;
   position: absolute;
-  top: 50rpx;
+  top: 5vh;
   padding-bottom: 260rpx;
 }
 .tr {
@@ -191,7 +191,7 @@ page {
   align-items: center;
 }
 
-/* .botton-right-float{
+/* .button-right-float{
   color: #ffffff;
   position: fixed;
   display: flex;


### PR DESCRIPTION
- 统一两个页面主要按钮样式和位置（将单词卡片中的按钮拆出到卡片外并调整按钮、container及卡片样式
- words页面增加“调整设置”按钮（选择性显示）
- 修改询问是否屏蔽高中单词的弹窗中的文字内容