### PR TITLE
1.1.1 修复词库信息更新时导致难度设定丢失问题

### DIFF
--- a/miniprogram/app.js
+++ b/miniprogram/app.js
@@ -34,15 +34,33 @@ App({
     wx.getStorage({
       key: 'dictInfo',
       success (res) {
+        console.log('getStorage - dictInfo - success:', res)
         _this.globalData.dictInfo = res.data
         if (!_this.globalData.dictInfo.hasOwnProperty('dictNames')) { // 把clusters_and_domains改名成dictNames时的临时措施
           _this.globalData.dictInfo.dictNames = _this.globalData.dictInfo.clusters_and_domains
+        }
+        // 临时：将难度设置(diff_threshold)存储位置从 dictNames 中移出
+        if (!_this.globalData.dictInfo.hasOwnProperty('diff_thresholds')) {
+          _this.globalData.dictInfo.diff_thresholds = new Object()
+          let clusters = _this.globalData.dictInfo.dictNames
+          console.log(clusters)
+          for (let cluster_keyi in Object.keys(clusters)) {
+            let dicts = clusters[Object.keys(clusters)[cluster_keyi]]
+            for (let dict_keyi in Object.keys(dicts)) {
+              let dict = dicts[Object.keys(dicts)[dict_keyi]]
+              if (dict.hasOwnProperty('diff_threshold')) {
+                _this.globalData.dictInfo.diff_thresholds[Object.keys(dicts)[dict_keyi]] = dict.diff_threshold
+              }
+            }
+          }
+          console.log('diff_thresholds', _this.globalData.dictInfo.diff_thresholds)
         }
         if (!_this.globalData.dictInfo.hasOwnProperty('daily_target')) {
           _this.globalData.dictInfo.daily_target = 30
         }
       },
       fail () {
+        console.log('getStorage - dictInfo - fail:')
         _this.globalData.dictInfo =   {"_id":"diff_showcase_test","modes":["识记模式","检验模式"],"dictNames":{"生命科学":
         {
             "基础词库":{
@@ -57,7 +75,7 @@ App({
             "生信&计算":{"paper_count":18965.0,
             "diff_showcase": ["network", "database", "reconstruct", "indices", "discharge", "cortex", "fuzzy", "probe", "primer", "poisson"]}
             }
-            },"daily_target":30.0,"marker":12.0}
+            },"daily_target":30.0,"marker":12.0, diff_thresholds:{}}
       },
       complete () {
         // 慢慢进行一个是否需要更新词库的判断

--- a/miniprogram/child_package/pages/setting/setting.js
+++ b/miniprogram/child_package/pages/setting/setting.js
@@ -45,13 +45,13 @@ Page({
 
     if (this.data.show_diff_setting) {
       let newDiffcultyThreshold = this.data.difficulty / 100
-      let oldDiffcultyThreshold = globalDictInfo.dictNames.生命科学[globalDictInfo.useDict].diff_threshold
+      let oldDiffcultyThreshold = globalDictInfo.diff_thresholds[globalDictInfo.useDict]
       //necessary?
       if(oldDiffcultyThreshold != newDiffcultyThreshold)
       {
         app.words_need_reload = true
       }
-      globalDictInfo.dictNames.生命科学[globalDictInfo.useDict].diff_threshold = newDiffcultyThreshold
+      globalDictInfo.diff_thresholds[globalDictInfo.useDict] = newDiffcultyThreshold
     }
     
     globalDictInfo.daily_target = this.data.daily_target_array[this.data.daily_target_index]
@@ -81,8 +81,8 @@ Page({
   onShow() {
     try {
       this.setData({
-        difficulty: app.globalData.dictInfo.dictNames.生命科学[app.globalData.dictInfo.useDict].hasOwnProperty('diff_threshold')
-        ? Math.round(app.globalData.dictInfo.dictNames.生命科学[app.globalData.dictInfo.useDict].diff_threshold * 100)
+        difficulty: app.globalData.dictInfo.diff_thresholds.hasOwnProperty(app.globalData.dictInfo.useDict)
+        ? Math.round(app.globalData.dictInfo.diff_thresholds[app.globalData.dictInfo.useDict] * 100)
         : 0
       })
     } catch(e) {

--- a/miniprogram/child_package/pages/words/words.js
+++ b/miniprogram/child_package/pages/words/words.js
@@ -15,7 +15,7 @@ Page({
     showSetting: app.globalData.dictInfo.hasOwnProperty('no_high_school')
      || (
         app.globalData.dictInfo.dictNames.生命科学[app.globalData.dictInfo.useDict]
-        && app.globalData.dictInfo.dictNames.生命科学[app.globalData.dictInfo.useDict].hasOwnProperty('diff_threshold')
+        && app.globalData.dictInfo.diff_thresholds.hasOwnProperty(app.globalData.dictInfo.useDict)
        ),
     since_touch_setting: 0,
     setting_opacity: 0.99,
@@ -52,7 +52,7 @@ Page({
       dblog.logAction("configDifficultyFilter", difficultyThreshold)
       this.onReload()
       let dataDict = this.data.dictionary
-      app.globalData.dictInfo.dictNames.生命科学[dataDict.getUseDict()].diff_threshold = difficultyThreshold
+      app.globalData.dictInfo.diff_thresholds[dataDict.getUseDict()] = difficultyThreshold
       wx.setStorage({
         key: 'dictInfo',
         data: app.globalData.dictInfo
@@ -64,9 +64,9 @@ Page({
   {
     //未设定过难度filter 则弹窗询问是否跳转设置页
     let dataDict = this.data.dictionary
-    if(dataDict.isFilterEnabled() && !app.globalData.dictInfo.dictNames.生命科学[dataDict.getUseDict()].hasOwnProperty('diff_threshold'))
+    if(dataDict.isFilterEnabled() && !app.globalData.dictInfo.diff_thresholds.hasOwnProperty(dataDict.getUseDict()))
     {
-      app.globalData.dictInfo.dictNames.生命科学[dataDict.getUseDict()].diff_threshold = 0
+      app.globalData.dictInfo.diff_thresholds[dataDict.getUseDict()] = 0
       // 加载难度示例
       let cal_font_size = function (word) {
         let len = app.count_display_length(word)
@@ -184,10 +184,9 @@ Page({
       let filtername = dictInfo.no_high_school == true ? 'no_high_school' : 'none'
       this.configFilter(filtername)
     }
-    
-    if(dataDict.isFilterEnabled() && dictInfo.dictNames.生命科学[dictInfo.useDict].hasOwnProperty('diff_threshold'))
+    if(dataDict.isFilterEnabled() && dictInfo.diff_thresholds.hasOwnProperty(dictInfo.useDict))
     {
-      let difficultyThreshold = dictInfo.dictNames.生命科学[dictInfo.useDict].diff_threshold
+      let difficultyThreshold = dictInfo.diff_thresholds[dictInfo.useDict]
       this.configDifficultyFilter(difficultyThreshold)
     }
 
@@ -423,10 +422,10 @@ Page({
       let filtername = dictInfo.no_high_school == true ? 'no_high_school' : 'none'
       this.configFilter(filtername)
     }
-    if(dataDict.isFilterEnabled() && dictInfo.dictNames.生命科学[dictInfo.useDict].hasOwnProperty('diff_threshold')
+    if(dataDict.isFilterEnabled() && dictInfo.diff_thresholds.hasOwnProperty(dictInfo.useDict)
       && dataDict.hasOwnProperty('dictionary'))
     {
-      let difficultyThreshold = dictInfo.dictNames.生命科学[dictInfo.useDict].diff_threshold
+      let difficultyThreshold = dictInfo.diff_thresholds[dictInfo.useDict]
       this.configDifficultyFilter(difficultyThreshold)
     }
 

--- a/miniprogram/utils/dblog.js
+++ b/miniprogram/utils/dblog.js
@@ -21,7 +21,7 @@ function reportUserLog() {
     scene: wx.getLaunchOptionsSync().scene
   }
   try {
-    temp.difficulty_setting = app.globalData.dictInfo.dictNames.生命科学[temp.useDict].diff_threshold
+    temp.difficulty_setting = app.globalData.dictInfo.diff_thresholds[temp.useDict]
   } catch {}
   db.collection('log').add({
     data : temp,


### PR DESCRIPTION
将难度设置(diff_threshold)存储位置从 dictNames 中移出，成为 dictInfo 一个单独的 property 